### PR TITLE
Add a Dockerfile for easier building and debugging

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "../Dockerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	"customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools-extension-pack",
+				"eamodio.gitlens",
+                "LucianIrsigler.nasm",
+				"ms-azuretools.vscode-docker"
+            ]
+        }
+    }
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:latest
 
 # Disable any Ubuntu interactive frontend
 ENV DEBIAN_FRONTEND=noninteractive
+ENV NO_AT_BRIDGE=1
 
 # Update the image to the latest base packages
 RUN apt update
@@ -12,7 +13,9 @@ RUN apt -y install \
     build-essential \
     clang \
     curl \
+    gdb \
     git \
+    lld \
     lldb \
     llvm \
     nasm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:latest
+
+# Disable any Ubuntu interactive frontend
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update the image to the latest base packages
+RUN apt update
+RUN apt -y upgrade
+
+# Install required software
+RUN apt -y install \
+    build-essential \
+    clang \
+    curl \
+    git \
+    lldb \
+    llvm \
+    nasm \
+    qemu-system \
+    zsh
+
+ENTRYPOINT [ "zsh" ]


### PR DESCRIPTION
This Change adds a Dockerfile to allow users to configure their development environment using Docker instead of installing all of the dependencies manually. Tested on Ubuntu 24.04 LTS.