### PR TITLE
Fix boot address and start script

### DIFF
--- a/Chapter 3/3.1 - The IDT/bootloader/boot.asm
+++ b/Chapter 3/3.1 - The IDT/bootloader/boot.asm
@@ -31,8 +31,8 @@ call print_bios
 ; of the drive. Note: Only bl will be used
 mov bx, 0x0002
 
-; Now we want to load 3 sectors for the bootloader and kernel
-mov cx, 0x000A
+; Now we want to load 11 sectors for the bootloader and kernel
+mov cx, 0x000B
 
 ; Finally, we want to store the new sector immediately after the first
 ; loaded sector, at adress 0x7E00. This will help a lot with jumping between
@@ -132,7 +132,7 @@ jmp $
 %include "long_mode/clear.asm"
 %include "long_mode/print.asm"
 
-kernel_start:                   equ 0x8200              ; Kernel is at 1MB
+kernel_start:                   equ 0x8350              ; Kernel is at 1MB
 long_mode_note:                 db `Now running in fully-enabled, 64-bit long mode!`, 0
 style_blue:                     equ 0x1F
 

--- a/Chapter 3/3.1 - The IDT/build.sh
+++ b/Chapter 3/3.1 - The IDT/build.sh
@@ -15,6 +15,7 @@ if [ "$boot_result" = "0" ] && [ "$make_result" = "0" ]
 then
     cp bootloader/boot ./os.img
     cat kernel/kernel >> os.img
+    dd if=/dev/zero bs=1 count=512 >> os.img
 
     fsize=$(wc -c < os.img)
     sectors=$(( $fsize / 512 ))


### PR DESCRIPTION
This should temporarily fix #8. The emulator doesn't seem to want to return from the method gracefully, so that's something I'll have to submit as a separate PR. I could afford to do some cleanup of the build scripts and such anyway.

The boot loop issue was caused because the `_start` symbol wasn't at 0x8200 like I expected, but instead at 0x8300. This led to a triple-fault which trapped the user in a boot loop. I'll have to figure out a way to pin the `_start` address in the future, but for now using GDB to get the address and plugging that into the `KERNEL_START` variable seems to do the trick.